### PR TITLE
Instana OpenTracing for NGINX Ingress, Part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ export E2E_CHECK_LEAKS
 export SLOW_E2E_THRESHOLD
 
 # Set default base image dynamically for each arch
-BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.90
+BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.91
 
 ifeq ($(ARCH),arm)
 	QEMUARCH=arm

--- a/docs/user-guide/third-party-addons/opentracing.md
+++ b/docs/user-guide/third-party-addons/opentracing.md
@@ -19,13 +19,15 @@ We must also set the host to use when uploading traces:
 zipkin-collector-host: zipkin.default.svc.cluster.local
 jaeger-collector-host: jaeger-agent.default.svc.cluster.local
 datadog-collector-host: datadog-agent.default.svc.cluster.local
+instana-agent-host: instana-agent.default.svc.cluster.local
 ```
-NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.  
+NOTE: While the option is called `jaeger-collector-host`, you will need to point this to a `jaeger-agent`, and not the `jaeger-collector` component.
 
 Next you will need to deploy a distributed tracing system which uses OpenTracing.
 [Zipkin](https://github.com/openzipkin/zipkin) and
 [Jaeger](https://github.com/jaegertracing/jaeger) and
-[Datadog](https://github.com/DataDog/dd-opentracing-cpp)
+[Datadog](https://github.com/DataDog/dd-opentracing-cpp) and
+[Instana](https://github.com/instana/cpp-sensor)
 have been tested.
 
 Other optional configuration options:
@@ -67,6 +69,12 @@ datadog-service-name
 
 # specifies the operation name to use for any traces collected, Default: nginx.handle
 datadog-operation-name-override
+
+# specifies the port to use when uploading traces, Default 42699
+instana-agent-port
+
+# specifies the service name to use for any traces created, Default: nginx
+instana-service-name
 ```
 
 All these options (including host) allow environment variables, such as `$HOSTNAME` or `$HOST_IP`. In the case of Jaeger, if you have a Jaeger agent running on each machine in your cluster, you can use something like `$HOST_IP` (which can be 'mounted' with the `status.hostIP` fieldpath, as described [here](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#capabilities-of-the-downward-api)) to make sure traces will be sent to the local agent.

--- a/images/nginx/Makefile
+++ b/images/nginx/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 0.0.0 shouldn't clobber any released builds
-TAG ?= 0.90
+TAG ?= 0.91
 REGISTRY ?= quay.io/kubernetes-ingress-controller
 ARCH ?= $(shell go env GOARCH)
 DOCKER ?= docker

--- a/images/nginx/README.md
+++ b/images/nginx/README.md
@@ -10,6 +10,7 @@ This custom image contains:
 - [opentracing-cpp](https://github.com/opentracing/opentracing-cpp)
 - [zipkin-cpp-opentracing](https://github.com/rnburn/zipkin-cpp-opentracing)
 - [dd-opentracing-cpp](https://github.com/DataDog/dd-opentracing-cpp)
+- [instana-opentracing-cpp](https://github.com/instana/cpp-sensor)
 - [ModSecurity-nginx](https://github.com/SpiderLabs/ModSecurity-nginx) (only supported in x86_64)
 - [brotli](https://github.com/google/brotli)
 - [geoip2](https://github.com/leev/ngx_http_geoip2_module)

--- a/internal/ingress/controller/config/config.go
+++ b/internal/ingress/controller/config/config.go
@@ -525,6 +525,17 @@ type Configuration struct {
 	// Default: nginx.handle
 	DatadogOperationNameOverride string `json:"datadog-operation-name-override"`
 
+	// InstanaAgentHost specifies the Instana agent host to use when uploading traces
+	InstanaAgentHost string `json:"instana-agent-host"`
+
+	// InstanaAgentPort specifies the port to use when uploading traces
+	// Default: 42699
+	InstanaAgentPort int `json:"instana-agent-port"`
+
+	// InstanaServiceName specifies the service name to use for any traces created
+	// Default: nginx
+	InstanaServiceName string `json:"instana-service-name"`
+
 	// MainSnippet adds custom configuration to the main section of the nginx configuration
 	MainSnippet string `json:"main-snippet"`
 
@@ -734,6 +745,8 @@ func NewDefault() Configuration {
 		DatadogServiceName:           "nginx",
 		DatadogCollectorPort:         8126,
 		DatadogOperationNameOverride: "nginx.handle",
+		InstanaServiceName:           "nginx",
+		InstanaAgentPort:             42699,
 		LimitReqStatusCode:           503,
 		LimitConnStatusCode:          503,
 		SyslogPort:                   514,

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -1059,6 +1059,12 @@ const datadogTmpl = `{
   "operation_name_override": "{{ .DatadogOperationNameOverride }}"
 }`
 
+const instanaTmpl = `{
+  "service": "{{ .InstanaServiceName }}",
+  "agent_host": "{{ .InstanaAgentHost }}",
+  "agent_port": {{ .InstanaAgentPort }}
+}`
+
 func createOpentracingCfg(cfg ngx_config.Configuration) error {
 	var tmpl *template.Template
 	var err error
@@ -1075,6 +1081,11 @@ func createOpentracingCfg(cfg ngx_config.Configuration) error {
 		}
 	} else if cfg.DatadogCollectorHost != "" {
 		tmpl, err = template.New("datadog").Parse(datadogTmpl)
+		if err != nil {
+			return err
+		}
+	} else if cfg.InstanaAgentHost != "" {
+		tmpl, err = template.New("instana").Parse(instanaTmpl)
 		if err != nil {
 			return err
 		}

--- a/internal/ingress/controller/template/template.go
+++ b/internal/ingress/controller/template/template.go
@@ -927,6 +927,8 @@ func buildOpentracing(input interface{}) string {
 		}
 	} else if cfg.DatadogCollectorHost != "" {
 		buf.WriteString("opentracing_load_tracer /usr/local/lib/libdd_opentracing.so /etc/nginx/opentracing.json;")
+	} else if cfg.InstanaAgentHost != "" {
+		buf.WriteString("opentracing_load_tracer /usr/local/lib/libinstana_sensor.so /etc/nginx/opentracing.json;")
 	}
 
 	buf.WriteString("\r\n")

--- a/internal/ingress/controller/template/template_test.go
+++ b/internal/ingress/controller/template/template_test.go
@@ -1177,6 +1177,16 @@ func TestBuildOpenTracing(t *testing.T) {
 		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
 	}
 
+	cfgInstana := config.Configuration{
+		EnableOpentracing:    true,
+		InstanaAgentHost: "instana-agent-host.com",
+	}
+	expected = "opentracing_load_tracer /usr/local/lib/libinstana_sensor.so /etc/nginx/opentracing.json;\r\n"
+	actual = buildOpentracing(cfgInstana)
+
+	if expected != actual {
+		t.Errorf("Expected '%v' but returned '%v'", expected, actual)
+	}
 }
 
 func TestEnforceRegexModifier(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

PR preparation to integrate Instana OpenTracing with the Kubernetes NGINX Ingress.

Before this PR can be opened against the Kubernetes ingress-nginx project, several steps are needed however:

- [ ] The NGINX Ingress is using OpenResty. For the Instana tracer to work, we need NGINX > 1.19.11 but OpenResty is still based on NGINX 1.15 and no higher version is currently available (https://openresty.org/en/ann-1015008001.html)
- [ ] The Instana CPP Tracer needs to be publicly released
- [ ] This PR should be split in two separate PRs, so that first the base-image can be build and versioned, and then the config changes made available. (see /ingress-nginx/pull/3767) and (/ingress-nginx/pull/3766)

Current state with this PR is Instana tracer is being loaded, but the following errors appear in the log:
```
Error: exit status 1
2019/07/23 10:26:31 [error] 6506#6506: opentracing_propagate_context before tracer loaded
nginx: [error] opentracing_propagate_context before tracer loaded
nginx: configuration file /tmp/nginx-cfg069564328 test failed
```


To build locally (and with Minikube), I've used the following steps:

- Update the `Makefile` to change these two lines:

```
-  BASEIMAGE?=quay.io/kubernetes-ingress-controller/nginx-$(ARCH):0.90
+  BASEIMAGE?=miel/ingress-controller/nginx-$(ARCH):dev

-       @$(DOCKER) build --no-cache --pull -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)/rootfs
+       @$(DOCKER) build -t $(MULTI_ARCH_IMG):$(TAG) $(TEMP_DIR)/rootfs

```

- `cd images/nginx`
- `ARCH=amd64 TAG=dev REGISTRY=$USER/ingress-controller make container` (builds the NGINX base image together with e.g. Instana tracing library)
- `cd ../..`
- `docker save miel/ingress-controller/nginx-amd64:dev | (eval $(minikube docker-env) && docker load)` (copy the image to Minikube)
- `make dev-env` (builds full container and deploys on Kubernetes)

To enable the Instana agent, the following changes to configuration are needed:
- Modify `deploy/cloud-generic/deployment.yaml` to set (add):

```
            - name: HOST_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.hostIP
```

- Deploy the following config-map:

```
apiVersion: v1
kind: ConfigMap
data:
  enable-opentracing: "true"
  instana-agent-host: "$HOSTIP"
  instana-agent-port: "42699"
  instana-service-name: "my-nginx-ingress"
metadata:
  name: nginx-configuration
  namespace: ingress-nginx
```